### PR TITLE
Error if character dates are non-ISO format OR user doesn't specify format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ matrix:
     - os: osx
       osx_image: xcode8.3
 
-
-r_github_packages:
-  - jimhester/covr
-
 warnings_are_errors: true
 
 notifications:
@@ -27,3 +23,13 @@ notifications:
 
 after_success:
   - if [[ "${R_CODECOV}" ]]; then Rscript -e 'covr::codecov()'; fi
+
+env:
+  global:
+    - NOT_CRAN: true
+    - R_BUILD_ARGS="--resave-data --compact-vignettes=gs+qpdf"
+    - R_CHECK_ARGS="--as-cran --timings"
+    - R_CHECK_TIME="TRUE"
+    - R_CHECK_TESTS="TRUE"
+    - _R_CHECK_TIMINGS_="0"
+    - _R_CHECK_SYSTEM_CLOCK_="0"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
 # aweek 0.2.0.9000
 
-* subsetting and concatenating methods added to the `aweek` class (see #1)
-* documentation divided into smaller chunks
+* Subsetting and concatenating methods added to the `aweek` class (see #1)
+* Documentation divided into smaller chunks
 * `as.POSIXlt()` bug where `tz` was not being passed was fixed.
 * `date2week()`: an error is now issued if users specify non-ISO 8601 dates OR
   don't specify a `format` option. (found: @scottyaz, #2)
+* Best practices added to vignette
+* Fix test that would fail every seven days on CRAN
 
 # aweek 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * documentation divided into smaller chunks
 * `as.POSIXlt()` bug where `tz` was not being passed was fixed.
 * `date2week()`: an error is now issued if users specify non-ISO 8601 dates OR
-  don't specify a `format` option.
+  don't specify a `format` option. (found: @scottyaz, #2)
 
 # aweek 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,9 @@
 
 * subsetting and concatenating methods added to the `aweek` class (see #1)
 * documentation divided into smaller chunks
-* bug in `as.POSIXlt()` where `tz` was not being passed was fixed.
+* `as.POSIXlt()` bug where `tz` was not being passed was fixed.
+* `date2week()`: an error is now issued if users specify non-ISO 8601 dates OR
+  don't specify a `format` option.
 
 # aweek 0.1.0
 

--- a/R/date2week.R
+++ b/R/date2week.R
@@ -20,10 +20,6 @@
 #'   caution when using this with a large date range as the resulting factor can
 #'   contain all days between dates_.
 #' 
-#' @param format if `x` is a character, this format will be used to convert it
-#'   to a date. Defaults to `YYYY-MM-DD`. An error will be issued if the date
-#'   could not be converted
-#' 
 #' @param ... arguments passed to [as.POSIXlt()], unused in all other cases.
 #' 
 #' @details Weeks differ in their start dates depending on context. The ISO
@@ -38,6 +34,13 @@
 #'   these do not provide seamless conversion from dates to epiweeks with 
 #'   non-standard start dates. This package provides a lightweight utility to
 #'   be able to convert each day.
+#'
+#' @note `date2week()` will initially convert the input with [as.POSIXlt()] and
+#'   use that to calculate the week. If the user supplies character input, it
+#'   is expected that the input will be of the format yyyy-mm-dd _unless_ the 
+#'   user explicitly passes the "format" parameter to [as.POSIXlt()]. If the
+#'   input is not in yyyy-mm-dd and the format parameter is not passed, 
+#'   `date2week()` will result in an error.
 #'
 #' @author Zhian N. Kamvar
 #' @export
@@ -99,9 +102,21 @@
 #' # Epiweek definition: Sunday -- 7 
 #' date2week(dat, 7)
 #' date2week(dat, "Sunday")
-date2week <- function(x, week_start = 1, floor_day = FALSE, numeric = FALSE, factor = FALSE, format = "%Y-%m-%d", ...) {
+date2week <- function(x, week_start = 1, floor_day = FALSE, numeric = FALSE, factor = FALSE, ...) {
 
-  x  <- tryCatch(as.POSIXlt(x, format = format, ...), error = function(e) e)
+  format_exists <- !is.null(list(...)$format)
+
+  if (!inherits(x, "aweek") && is.character(x) && !format_exists) {
+    iso_std <- grepl("^[0-9]{4}[^[:alnum:]]+[01][0-9][^[:alnum:]]+[0-3][0-9]$", trimws(x))
+    iso_std[is.na(x)] <- TRUE # prevent false alarms
+    if (!all(iso_std)) {
+      msg <- paste("Not all dates are in ISO 8601 standard format (yyyy-mm-dd).",
+                   "The first incorrect date is %s"
+      )
+      stop(sprintf(msg, x[!iso_std][1]))
+    }
+  }
+  x  <- tryCatch(as.POSIXlt(x, ...), error = function(e) e)
 
   if (inherits(x, "error")) {
     mc <- match.call()

--- a/R/date2week.R
+++ b/R/date2week.R
@@ -20,6 +20,10 @@
 #'   caution when using this with a large date range as the resulting factor can
 #'   contain all days between dates_.
 #' 
+#' @param format if `x` is a character, this format will be used to convert it
+#'   to a date. Defaults to `YYYY-MM-DD`. An error will be issued if the date
+#'   could not be converted
+#' 
 #' @param ... arguments passed to [as.POSIXlt()], unused in all other cases.
 #' 
 #' @details Weeks differ in their start dates depending on context. The ISO
@@ -95,9 +99,9 @@
 #' # Epiweek definition: Sunday -- 7 
 #' date2week(dat, 7)
 #' date2week(dat, "Sunday")
-date2week <- function(x, week_start = 1, floor_day = FALSE, numeric = FALSE, factor = FALSE, ...) {
+date2week <- function(x, week_start = 1, floor_day = FALSE, numeric = FALSE, factor = FALSE, format = "%Y-%m-%d", ...) {
 
-  x  <- tryCatch(as.POSIXlt(x, ...), error = function(e) e)
+  x  <- tryCatch(as.POSIXlt(x, format = format, ...), error = function(e) e)
 
   if (inherits(x, "error")) {
     mc <- match.call()

--- a/R/print.aweek.R
+++ b/R/print.aweek.R
@@ -74,11 +74,16 @@ c.aweek <- function(..., recursive = FALSE, use.names = TRUE) {
   is_factor  <- is.factor(the_dots[[1]])
   week_start <- attr(the_dots[[1]], "week_start")
   aweeks     <- vlogic(the_dots, inherits, "aweek")
+  factors    <- vlogic(the_dots, inherits, "factor")
+  if (any(factors)) {
+    the_dots[factors] <- lapply(the_dots[factors], date2week, week_start = week_start) 
+  }
   starts     <- vapply(the_dots[aweeks], attr, integer(1), "week_start")
   if (!all(starts == starts[1]) || !all(aweeks)) {
     # Find all characters that are aweeks without the attributes
-    are_chars  <- !aweeks & vlogic(the_dots, inherits, "character")
+    are_chars  <- !aweeks & vlogic(the_dots, inherits, c("character", "factor"))
     if (any(are_chars)) {
+      the_dots[are_chars] <- lapply(the_dots[are_chars], as.character)
       are_weeks <- are_chars & vallgrep(the_dots, "\\d{4}-W\\d{2}-?[1-7]?")
       if (any(are_weeks)) {
         # convert the week chars to dates if they exist

--- a/R/print.aweek.R
+++ b/R/print.aweek.R
@@ -47,7 +47,7 @@ print.aweek <- function(x, ...) {
   y <- x
   attr(x, "week_start") <- NULL
   class(x) <- class(x)[class(x) != "aweek"]
-  NextMethod()
+  NextMethod("print")
   invisible(y)
 
 }
@@ -58,10 +58,9 @@ print.aweek <- function(x, ...) {
 `[.aweek` <- function(x, i) {
 
   ws <- attr(x, "week_start")
-  x <- NextMethod()
-  class(x) <- "aweek"
-  attr(x, "week_start") <- ws
-  x
+  y  <- NextMethod("[")
+  attr(y, "week_start") <- ws
+  y
 
 }
 
@@ -71,6 +70,7 @@ print.aweek <- function(x, ...) {
 c.aweek <- function(..., recursive = FALSE, use.names = TRUE) {
 
   the_dots   <- list(...)
+  is_factor  <- is.factor(the_dots[[1]])
   week_start <- attr(the_dots[[1]], "week_start")
   aweeks     <- vapply(the_dots, inherits, logical(1), "aweek")
   starts     <- vapply(the_dots[aweeks], attr, integer(1), "week_start")
@@ -80,6 +80,9 @@ c.aweek <- function(..., recursive = FALSE, use.names = TRUE) {
   res        <- unlist(the_dots, recursive = recursive, use.names = TRUE)
   class(res) <- "aweek"
   attr(res, "week_start") <- week_start
+  if (is_factor) {
+    res <- date2week(res, week_start = week_start, factor = TRUE)
+  }
   res
 
 }

--- a/R/print.aweek.R
+++ b/R/print.aweek.R
@@ -11,6 +11,11 @@
 #'
 #' @return an object of class `aweek`
 #'
+#' @description The method `c.aweek()` will always return an `aweek` object with
+#'   the same `week_start` attribute as the first object in the list. If the
+#'   first object is also a factor, then the output will be re-leveled. If
+#'   week-like characters are presented (e.g. "2019-W10-1"), then these are
+#'   assumed to have the same `week_start` as the first object. 
 #'
 #' @export
 #' @rdname aweek-class

--- a/R/utils.R
+++ b/R/utils.R
@@ -33,3 +33,17 @@ week_in_year <- function(the_date) {
   jan1 <- as.Date(sprintf("%s-01-01", format(the_date, "%Y")))
   1L + (as.numeric(the_date) - as.numeric(jan1)) %/% 7L
 }
+
+
+vlogic <- function(x, FUN, ...) {
+
+  vapply(x, FUN = match.fun(FUN), FUN.VALUE = logical(1), ...)
+
+}
+
+vallgrep <- function(x, PATTERN) {
+
+  FUN <- function(i, PATTERN) all(grepl(PATTERN, i))
+  vapply(x, FUN, logical(1), PATTERN)
+
+}

--- a/man/aweek-class.Rd
+++ b/man/aweek-class.Rd
@@ -25,6 +25,13 @@
 an object of class \code{aweek}
 }
 \description{
+The method \code{c.aweek()} will always return an \code{aweek} object with
+the same \code{week_start} attribute as the first object in the list. If the
+first object is also a factor, then the output will be re-leveled. If
+week-like characters are presented (e.g. "2019-W10-1"), then these are
+assumed to have the same \code{week_start} as the first object.
+}
+\details{
 The aweek class is a character or factor in the format YYYY-Www(-d) with a
 "week_start" attribute containing an integer specifying which day of the ISO
 8601 week each week should begin. This documentation shows how to print or

--- a/man/date2week.Rd
+++ b/man/date2week.Rd
@@ -6,7 +6,7 @@
 \title{Convert date to a an arbitrary week definition}
 \usage{
 date2week(x, week_start = 1, floor_day = FALSE, numeric = FALSE,
-  factor = FALSE, format = "\%Y-\%m-\%d", ...)
+  factor = FALSE, ...)
 
 week2date(x, week_start = 1, floor_day = FALSE)
 }
@@ -31,10 +31,6 @@ the sequence of weeks between the first and last date will be used. \emph{Take
 caution when using this with a large date range as the resulting factor can
 contain all days between dates}.}
 
-\item{format}{if \code{x} is a character, this format will be used to convert it
-to a date. Defaults to \code{YYYY-MM-DD}. An error will be issued if the date
-could not be converted}
-
 \item{...}{arguments passed to \code{\link[=as.POSIXlt]{as.POSIXlt()}}, unused in all other cases.}
 }
 \description{
@@ -53,6 +49,14 @@ While there are packages that provide conversion for ISOweeks and epiweeks,
 these do not provide seamless conversion from dates to epiweeks with
 non-standard start dates. This package provides a lightweight utility to
 be able to convert each day.
+}
+\note{
+\code{date2week()} will initially convert the input with \code{\link[=as.POSIXlt]{as.POSIXlt()}} and
+use that to calculate the week. If the user supplies character input, it
+is expected that the input will be of the format yyyy-mm-dd \emph{unless} the
+user explicitly passes the "format" parameter to \code{\link[=as.POSIXlt]{as.POSIXlt()}}. If the
+input is not in yyyy-mm-dd and the format parameter is not passed,
+\code{date2week()} will result in an error.
 }
 \examples{
 

--- a/man/date2week.Rd
+++ b/man/date2week.Rd
@@ -6,7 +6,7 @@
 \title{Convert date to a an arbitrary week definition}
 \usage{
 date2week(x, week_start = 1, floor_day = FALSE, numeric = FALSE,
-  factor = FALSE, ...)
+  factor = FALSE, format = "\%Y-\%m-\%d", ...)
 
 week2date(x, week_start = 1, floor_day = FALSE)
 }
@@ -30,6 +30,10 @@ of days between the first and last date, but if \code{floor_date = TRUE}, then
 the sequence of weeks between the first and last date will be used. \emph{Take
 caution when using this with a large date range as the resulting factor can
 contain all days between dates}.}
+
+\item{format}{if \code{x} is a character, this format will be used to convert it
+to a date. Defaults to \code{YYYY-MM-DD}. An error will be issued if the date
+could not be converted}
 
 \item{...}{arguments passed to \code{\link[=as.POSIXlt]{as.POSIXlt()}}, unused in all other cases.}
 }

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -1,0 +1,82 @@
+context("subsetting tests")
+
+d <- as.Date("2018-12-31") + 0:14
+x <- date2week(d, week_start = "Monday")
+y <- date2week(d, week_start = "Saturday")
+dd <- date2week(c(d, as.Date("2019-01-15")), week_start = "Monday")
+
+
+test_that("subsetting returns an aweek object", {
+
+  expect_identical(x[], x)
+  expect_is(x[1], "aweek")
+  expect_is(y[1], "aweek")
+  expect_identical(as.Date(x[1]), d[1])
+  expect_identical(as.Date(y[1]), d[1])
+
+})
+
+
+test_that("concatenation returns aweek object with the correct week_start attribute", {
+
+  xy <- c(x, y)
+  yx <- c(y, x)
+  
+  expect_identical(attr(xy, "week_start"), 1L)
+  expect_identical(attr(yx, "week_start"), 6L)
+
+})
+
+test_that("characters can be added", {
+
+  xw <- c(x, "2019-W03-2")
+  xd <- c(x, "2019-01-15")
+
+  expect_identical(xw, xd)
+  expect_identical(xw, dd)
+
+})
+
+
+test_that("dates can be added", {
+
+  xd <- c(x, as.Date("2019-01-15"))
+  expect_identical(xd, dd)
+
+})
+
+test_that("POSIXt objects can be added", {
+
+
+  xp <- c(x, as.POSIXlt("2019-01-15", tz = "UTC"))
+  xc <- c(x, as.POSIXct("2019-01-15", tz = "UTC"))
+  expect_identical(xp, xc)
+  expect_identical(xp, dd)
+
+})
+
+
+test_that("all objects can be added", {
+
+
+  xx <- c(x[1:5],
+          y[6:10], 
+          "2019-01-10", 
+          as.Date(c("2019-01-11", "2019-01-12")),
+          as.POSIXlt("2019-01-13"),
+          date2week("2019-01-14", week_start = "Tuesday"),
+          "2019-W03-2")
+
+  expect_identical(xx, dd)
+
+  yy <- c(y[1:5],
+          x[6:10], 
+          "2019-01-10", 
+          as.Date(c("2019-01-11", "2019-01-12")),
+          as.POSIXlt("2019-01-13"),
+          date2week("2019-01-14", week_start = "Tuesday"),
+          "2019-W03-4")
+
+  expect_identical(yy, date2week(dd, week_start = "Saturday"))
+
+})

--- a/tests/testthat/test-subset.R
+++ b/tests/testthat/test-subset.R
@@ -38,6 +38,21 @@ test_that("characters can be added", {
 })
 
 
+test_that("factors force factors", {
+
+  xf <- c(date2week(d[1], week_start = "Monday", factor = TRUE), x[-1])
+  expect_is(xf, "factor")
+  expect_identical(levels(xf), as.character(x))
+  expect_identical(as.character(xf), as.character(x))
+
+  yf <- c(date2week(d[1], week_start = "Saturday", factor = TRUE), x[-1])
+  expect_is(yf, "factor")
+  expect_identical(levels(yf), as.character(y))
+  expect_identical(as.character(yf), as.character(y))
+
+})
+
+
 test_that("dates can be added", {
 
   xd <- c(x, as.Date("2019-01-15"))
@@ -64,7 +79,7 @@ test_that("all objects can be added", {
           "2019-01-10", 
           as.Date(c("2019-01-11", "2019-01-12")),
           as.POSIXlt("2019-01-13"),
-          date2week("2019-01-14", week_start = "Tuesday"),
+          date2week("2019-01-14", week_start = "Tuesday", factor = TRUE),
           "2019-W03-2")
 
   expect_identical(xx, dd)
@@ -74,7 +89,7 @@ test_that("all objects can be added", {
           "2019-01-10", 
           as.Date(c("2019-01-11", "2019-01-12")),
           as.POSIXlt("2019-01-13"),
-          date2week("2019-01-14", week_start = "Tuesday"),
+          date2week("2019-01-14", week_start = "Tuesday", factor = TRUE),
           "2019-W03-4")
 
   expect_identical(yy, date2week(dd, week_start = "Saturday"))

--- a/tests/testthat/test_conversion.R
+++ b/tests/testthat/test_conversion.R
@@ -22,6 +22,8 @@ test_that("a character can be converted to a date", {
 
 })
 
+test_that("", {})
+
 test_that("aweek can be converted to character", {
 
   expect_failure(expect_output(print(as.character(datw)), "aweek start: Friday"))

--- a/tests/testthat/test_conversion.R
+++ b/tests/testthat/test_conversion.R
@@ -22,7 +22,15 @@ test_that("a character can be converted to a date", {
 
 })
 
-test_that("", {})
+test_that("character can be converted to aweek if in YYYYMMDD format", {
+
+  expect_identical(date2week("2019/03/07", 5), datw)
+  expect_identical(date2week("2019:03:07", 5, format = "%Y:%m:%d"), datw)
+  expect_identical(date2week("3/7/2019", 5, format = "%m/%d/%Y"), datw)
+  expect_identical(date2week("7/3/2019", 5, format = "%d/%m/%Y"), datw)
+  expect_error(date2week(c("2019-07-03", "7/3/2019"), 5), "The first incorrect date is 7/3/2019")
+
+})
 
 test_that("aweek can be converted to character", {
 

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -59,7 +59,6 @@ with either `as.Date()` or `week2date()`:
 week2date(w)
 ```
 
-
 The `aweek` class 
 ---------------
 
@@ -70,7 +69,7 @@ day every time. It can be created like so:
 
 ```{r aweek}
 x <- "2019-W10-1"
-attr(x, "week_start") <- 7 # monday
+attr(x, "week_start") <- 7 # Sunday 
 class(x) <- "aweek"
 x
 class(x)
@@ -81,6 +80,23 @@ If you need to remove the class, you can just use `as.character()`:
 ```{r ascharacter}
 as.character(x)
 ```
+
+Best practices
+--------------
+
+The `date2week()` function only checks that dates are in ISO 8601 (yyyy-mm-dd)
+format before converting to weeks, *and otherwise assumes that the dates are
+accurate* so it's strongly recommended to make sure your dates are in either
+`Date` or `POISXt` format and accurate before converting to weeks. The 
+[lubridate](https://cran.r-project.org/package=lubridate) can be used for this
+purpose.
+
+Because the `week_start` arguments default to ISO week day 1 (Monday), it's
+recommended to specify `week_start` in `date2week()` and `week2date()` if you
+don't have an `aweek` object.
+
+Before you combine aweek objects, confirm that they are actually aweek objects
+with `inherits(myObject, "aweek")`. 
 
 
 Weekly aggregation 
@@ -111,8 +127,8 @@ weeks. You can use `factor = TRUE` in `date2week()` and it will automatically
 fill in any missing days (`floor_day = FALSE`) or weeks (`floor_day = TRUE`)
 
 ```{r factors}
-date2week(Sys.Date() + c(0, 15), week_start = 1, factor = TRUE)
-date2week(Sys.Date() + c(0, 15), week_start = 1, factor = TRUE, floor_day = TRUE)
+date2week(dat[1] + c(0, 15), week_start = 1, factor = TRUE)
+date2week(dat[1] + c(0, 15), week_start = 1, factor = TRUE, floor_day = TRUE)
 ```
 
 
@@ -123,15 +139,59 @@ You can also use `date2week()` to convert between different week definitions if
 you have an `aweek` object:
 
 
-```{r week2week}
+```{r week2week, R.options=list(width = 100)}
 w # week starting on Sunday
 date2week(w, week_start = "wednesday")
 
 # create a table with all days in the week
-res <- as.data.frame(matrix("", nrow = 10, ncol = 7), stringsAsFactors = FALSE)
-names(res) <- c("Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun")
-for (i in names(res)) res[[i]] <- date2week(w, week_start = i)
-as.data.frame(res)
+d <- dat[1] + 0:6
+res <- as.data.frame(matrix("", nrow = 7, ncol = 7), stringsAsFactors = FALSE)
+names(res) <- weekdays(d) # days of the week
+for (i in names(res)) res[[i]] <- date2week(d, week_start = i)
+res
+```
+
+All of these columns contain the same dates:
+
+```{r week2week2date}
+data.frame(lapply(res, as.Date))
+```
+
+
+Combining `aweek` objects
+-----------------------
+
+You can combine aweek objects with different `week_start` attributes. The 
+resulting `aweek` object will have the same `week_start` as the first object.
+
+```{r cweek2week}
+c(res$Sunday[1], res$Wednesday[2], res$Friday[3])
+c(res$Tuesday[1], res$Thursday[2], res$Friday[3])
+```
+
+You can also add dates to aweek objects:
+
+```{r add_dates}
+c(res$Monday, as.Date("2019-04-03"))
+```
+
+### Add characters with caution
+
+You can also add character representation of weeks, but be aware that **it is
+assumed that these have the same `week_start` as the first object.**
+
+```{r add_chars}
+s <- c(res$Saturday, "2019-W14-3")
+s
+m <- c(res$Monday, "2019-W14-3")
+m
+```
+
+**These will translate into different dates**
+
+```{r char2date}
+as.Date(s[7:8])
+as.Date(m[7:8])
 ```
 
 


### PR DESCRIPTION
This addresses #2 by only allowing ISO 8601 format dates to pass through if the user doesn't specify `format`:


``` r
library(aweek)
date2week("1984/11/24")
#> <aweek start: Monday>
#> [1] "1984-W47-6"
date2week("11/24/1984")
#> Error in date2week("11/24/1984"): Not all dates are in ISO 8601 standard format (yyyy-mm-dd). The first incorrect date is 11/24/1984
date2week("11/24/1984", format = "%m/%d/%Y")
#> <aweek start: Monday>
#> [1] "1984-W47-6"
```

<sup>Created on 2019-03-07 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>


Things left to do:

 - [x] add documentation showing that it is recommended to get the date into the correct format
 - [x] add tests 